### PR TITLE
Fixes  in KSPI ORS Resource definitions  and KSPI Methane Tank

### DIFF
--- a/RealFuels/KSPI_RF.cfg
+++ b/RealFuels/KSPI_RF.cfg
@@ -41,6 +41,59 @@
 	}
 }
 
+// update InterstellarAtmosphericPack
+@ATMOSPHERIC_RESOURCE_PACK_DEFINITION[InterstellarAtmosphericPack]:NEEDS[WarpPlugin]:FOR[RealFuels]
+{
+	@ATMOSPHERIC_RESOURCE_DEFINITION[EveNitrogen] 
+	{
+		resourceName = Nitrogen
+	}
+	@ATMOSPHERIC_RESOURCE_DEFINITION[KerbinHydrogen]
+	{
+		@resourceName = LqdHydrogen
+	}
+	@ATMOSPHERIC_RESOURCE_DEFINITION[KerbinNitrogen] 
+	{
+		resourceName = Nitrogen
+	}
+	@ATMOSPHERIC_RESOURCE_DEFINITION[KerbinOxygen]
+	{
+		@resourceName = LqdOxygen
+	}
+	@ATMOSPHERIC_RESOURCE_DEFINITION[KerbinMethane]
+	{
+		resourceName = LqdMethane
+	}
+	@ATMOSPHERIC_RESOURCE_DEFINITION[DunaNitrogen]
+	{
+		resourceName = Nitrogen
+	}
+	@ATMOSPHERIC_RESOURCE_DEFINITION[JoolHydrogen]
+	{
+		@resourceName = LqdHydrogen
+	}
+	@ATMOSPHERIC_RESOURCE_DEFINITION[JoolMethane]
+	{
+		resourceName = LqdMethane
+	}
+	@ATMOSPHERIC_RESOURCE_DEFINITION[JoolAmmonia]
+	{
+		resourceName = LqdAmmonia
+	}
+	@ATMOSPHERIC_RESOURCE_DEFINITION[JoolDeuterium]
+	{
+		resourceName = Deuterium
+	}
+	@ATMOSPHERIC_RESOURCE_DEFINITION[LaytheNitrogen] 
+	{
+		resourceName = Nitrogen
+	}
+	@ATMOSPHERIC_RESOURCE_DEFINITION[LaytheOxygen] 
+	{
+		@resourceName = LqdOxygen
+	}
+}
+
 //Resource Definition updates
 @OCEANIC_RESOURCE_DEFINITION[*]:HAS[#resourceName[Ammonia]]:NEEDS[WarpPlugin]:FOR[RealFuels]
 {
@@ -135,25 +188,52 @@
 	@density = 0.00042262
 }
 
+//@PART[FNMethaneTank*]:HAS[@RESOURCE[LqdMethane]&@RESOURCE[Oxidizer]&!MODULE[ModuleFuelTanks]]:NEEDS[WarpPlugin]:FOR[RealFuels]
+//{
+//	MODULE
+//	{
+//		name = ModuleFuelTanks
+//		temp = 0
+//		volume = 0
+//		type = Cryogenic
+//		@temp = #$../RESOURCE[LqdMethane]/maxAmount$
+//		@temp *= 4.412
+//		@volume = #$../MODULE[ModuleFuelTanks]/temp$
+//		@temp = #$../RESOURCE[Oxidizer]/maxAmount$
+//		@temp *= 5
+//		@volume += #$../MODULE[ModuleFuelTanks]/temp$
+//		!temp = 0
+//	}
+//	!RESOURCE[LqdMethane] {}
+//	!RESOURCE[Oxidizer] {}
+//}
+
 //Specific part fixes
-@PART[FNMethaneTank*]:HAS[@RESOURCE[LqdMethane]&@RESOURCE[Oxidizer]&!MODULE[ModuleFuelTanks]]:NEEDS[WarpPlugin]:FOR[RealFuels]
+@PART[FNMethaneTank3-1]:NEEDS[WarpPlugin]:FOR[RealFuels]
 {
-	MODULE
-	{
-		name = ModuleFuelTanks
-		temp = 0
-		volume = 0
-		type = Cryogenic
-		@temp = #$../RESOURCE[LqdMethane]/maxAmount$
-		@temp *= 4.412
-		@volume = #$../MODULE[ModuleFuelTanks]/temp$
-		@temp = #$../RESOURCE[Oxidizer]/maxAmount$
-		@temp *= 5
-		@volume += #$../MODULE[ModuleFuelTanks]/temp$
-		!temp = 0
-	}
-	!RESOURCE[LqdMethane] {}
-	!RESOURCE[Oxidizer] {}
+    MODULE
+    {
+        name = ModuleFuelTanks
+        temp = 0
+        volume = 0
+        type = Cryogenic
+	@volume = 17875.682
+    }
+    !RESOURCE[LqdMethane] {}
+    !RESOURCE[Oxidizer] {}
+}
+@PART[FNMethaneTank3-2]:NEEDS[WarpPlugin]:FOR[RealFuels]
+{
+    MODULE
+    {
+        name = ModuleFuelTanks
+        temp = 0
+        volume = 0
+        type = Cryogenic
+	@volume = 35751.364
+    }
+    !RESOURCE[LqdMethane] {}
+    !RESOURCE[Oxidizer] {}
 }
 
 @PART[*]:HAS[@MODULE[FNModuleResourceExtraction]]:NEEDS[WarpPlugin]:FOR[RealFuels]


### PR DESCRIPTION
- Replaces ORS KSPI Hydrogen (Liquid Fuel & ORS KSPI Oxigen (Oxidiser) to proper RealFuel resource (LqdHydrogen & LqdOxygen)
- Links ORS  Nitrogen & ORS Methan to proper RealFuel resource
- Disabled MM code that should add Cryogenic tanks to Methane but fails with the new version of MM
- Temporary add MM code that will do the same but less fancy but will actually work (less flexible)
